### PR TITLE
to make init/skin do its work in options

### DIFF
--- a/laydate.dev.js
+++ b/laydate.dev.js
@@ -13,7 +13,7 @@
 //全局配置，如果采用默认均不需要改动
 var config =  {
     path: '', //laydate所在路径
-    defSkin: 'default', //初始化皮肤
+    skin: 'default', //初始化皮肤
     format: 'YYYY-MM-DD', //日期格式
     min: '1900-01-01 00:00:00', //最小日期
     max: '2099-12-31 23:59:59', //最大日期
@@ -169,7 +169,7 @@ Dates.run = function(options){
     elem = options.elem ? S(options.elem) : target;
 
     as.elemv = /textarea|input/.test(elem.tagName.toLocaleLowerCase()) ? 'value' : 'innerHTML';
-    if (config.init) elem[as.elemv] = laydate.now(null, options.format || config.format)
+    if ('init' in options ? options.init : config.init) elem[as.elemv] = laydate.now(null, options.format || config.format)
 
     if(even && target.tagName){
         if(!elem || elem === Dates.elem){
@@ -192,6 +192,8 @@ Dates.run = function(options){
             });
         });
     }
+
+    chgSkin(options.skin || config.skin)
 };
 
 Dates.scroll = function(type){
@@ -845,8 +847,6 @@ Dates.events = function(){
 
 Dates.init = (function(){
     Dates.use('need');
-    Dates.use(as[4] + config.defSkin, as[3]);
-    Dates.skinLink = Dates.query('#'+as[3]);
 }());
 
 //重置定位
@@ -867,8 +867,12 @@ laydate.now = function(timestamp, format){
 };
 
 //皮肤选择
-laydate.skin = function(lib){
-    Dates.skinLink.href = Dates.getPath + as[4] + lib + as[5];
+laydate.skin = chgSkin;
+
+//内部函数
+function chgSkin(lib) {
+    Dates.use(as[4] + lib, as[3]);
+    Dates.skinLink = Dates.query('#'+as[3]);
 };
 
 }(window);


### PR DESCRIPTION
* ``init`` 被设置在了全局的 ``config`` 中，在 ``options`` 中作出更改不起作用，更改为在 ``options`` 设置 ``init`` 为 ``true/false`` 来设置 ``初始化 ／不初始化 ``  为当前日期
* 增加 ``skin`` 用来在 ``options`` 中直接设置皮肤，但当有多个 ``laydate`` 时，设置的皮肤会被覆盖