### PR TITLE
bug-fix: 修复自定义format包含数字提示格式错误的问题

### DIFF
--- a/src/laydate.js
+++ b/src/laydate.js
@@ -435,6 +435,7 @@
     var that = this
     ,options = that.config
     ,dateType = 'yyyy|y|MM|M|dd|d|HH|H|mm|m|ss|s'
+    ,safeType = '\\w'
     ,isStatic = options.position === 'static'
     ,format = {
       year: 'yyyy'
@@ -474,7 +475,7 @@
           if(/^y$/.test(item)) return '1,308';
           return '1,2';
         }() +'}' 
-      : '\\' + item;
+      : new RegExp(safeType).test(item) ? '' + item : '\\' + item;
       that.EXP_IF = that.EXP_IF + EXP;
       that.EXP_SPLIT = that.EXP_SPLIT + '(' + EXP + ')';
     });


### PR DESCRIPTION
```js
format: 'yyyy-MM-dd 23:59:59'
```
如上所示，当自定义format中包含其它字符，比如包含数字，指定默认时分秒，会提示格式错误。
原因是生成正则时只考虑了ymd这些正常的格式，而字母数字下划线这些不需要加'\\'。
目前我修改了生成正则的函数，以支持这些额外的格式要求。