### PR TITLE
修复当type: 'month'时，点击月份，日期选择器未自动关闭的issue

### DIFF
--- a/src/laydate.js
+++ b/src/laydate.js
@@ -1255,6 +1255,17 @@
             isAlone && (that[['startDate', 'endDate'][index]].year = ym);
             that.list('month', index);
           }
+          /**
+           * 如果非范围选择，且为年月选择器，点击了月列表，则完成年月选择，关闭选择器列表
+           * @author J.Soon <serdeemail@gmail.com>
+           */
+          if (!options.range) {
+            if(options.type === 'month' && type === 'month'){
+              that.checkDate('limit').calendar();
+              that.done();
+              that.setValue(that.parse()).remove();
+            }
+          }
         } else {
           that.checkDate('limit').calendar();
           that.closeList();


### PR DESCRIPTION
由于场景需要进行年月选择，但发现当设置type: 'month'时，选择月份后日期选择器并未自动关闭。

触发条件：
1. 非范围选择
2. 年月选择器
3. 点击了月列表中的月份

修复步骤：
1. 进行日期校验
2. 触发done回调函数
3. 设置年月并移除控件

实现效果：
![apr-18-2018 14-57-07](https://user-images.githubusercontent.com/7589350/38916180-fee78062-4318-11e8-9cde-d84c3d28410b.gif)
