### PR TITLE
修复日期范围在选取开始日期后,产生的各种错误

### DIFF
--- a/src/laydate.js
+++ b/src/laydate.js
@@ -724,6 +724,7 @@
     );
     
     that.checkDate().calendar(); //初始校验
+    that.endState = true; //范围选择的初始状态
     that.changeEvent(); //日期切换
     
     Class.thisElemDate = that.elemID;


### PR DESCRIPTION
对日期范围 (range: true)：
第一次选取开始日期后,默认的选区没有消失
第一次选取开始日期后,确定按钮呈现可点击状态，而且当起始\结束日期相同时, 如果结束日期小于开始日期,就会造成日历错乱.
...