### PR TITLE
修正月份范围选择类型比较开始和结束日期错误问题

### DIFF
--- a/src/laydate.js
+++ b/src/laydate.js
@@ -2297,6 +2297,11 @@
     if(options.range && options.type !== 'time'){
       start = start || options.dateTime;
       end = end || that.endDate;
+      //月份范围选择：默认日期为1号处理
+      if(options.type == 'month'){
+        start.date = 1;
+        end.date = 1;
+      }
       isOut = that.newDate(start).getTime() > that.newDate(end).getTime();
       
       //如果不在有效日期内，直接禁用按钮，否则比较开始和结束日期


### PR DESCRIPTION
当类型为月份范围选择且操作日期为30、31号时，容易出现前后日期判断错误问题。

比如：今天31号，前面时间默认 2023-03-31，后面时间默认为 2023-04-30，当后面时间选择3月时，只是改变月份，日期没有变化，变为 2023-03-30，导致后面时间小于前面时间，判断错误。